### PR TITLE
Update rsa_make_key.cpp

### DIFF
--- a/rsa_make_key.cpp
+++ b/rsa_make_key.cpp
@@ -14,6 +14,9 @@ int main(int argc, char** argv)
 	// Usage: rsa_make_key <private key file> <public key file>
 	const char* private_key = ARGV(1);
 	const char* public_key = ARGV(2);
+	
+	// otherwise we get an error error: 'ltm_desc' undeclared
+	extern const ltc_math_descriptor ltm_desc;
 
 	ltc_mp = ltm_desc;
 


### PR DESCRIPTION
This fix was found on this stack overflow: https://stackoverflow.com/questions/37955209/runtime-error-segmentation-fault-with-libtommath-and-libtomcrypt

otherwise at compilation time an error happens:  `` error: 'ltm_desc' undeclared (first use in this function)
   33 |     ltc_mp = ltm_desc;``